### PR TITLE
Fix specs line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@ Makefile.in linguist-generated
 Makefile.am linguist-generated
 ltmain.sh linguist-generated
 install-sh linguist-generated
+/specs/** -text


### PR DESCRIPTION
On Windows with Git `core.autocrlf` enabled, the compilation fails with the following errors, as the files in the `spec` folder (`enumglu.spec` and `glu.spec`) have incorrect line endings (CR LF vs LF):
```console
C:\superglu\libtess\tess.c(168): warning C4013: 'gluTessBeginPolygon' undefined; assuming extern returning int
C:\superglu\libtess\tess.c(172): warning C4013: 'gluTessBeginContour' undefined; assuming extern returning int
C:\superglu\libtess\tess.c(181): warning C4013: 'gluTessEndContour' undefined; assuming extern returning int
C:\superglu\libtess\tess.c(466): error C2371: 'gluTessBeginPolygon': redefinition; different basic types
C:\superglu\libtess\tess.c(480): error C2371: 'gluTessBeginContour': redefinition; different basic types
C:\superglu\libtess\tess.c(497): error C2371: 'gluTessEndContour': redefinition; different basic types
```